### PR TITLE
Made gulp callbacks work

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,10 @@ var deploy = function(options, callback) {
 				if (!repo.hasOwnProperty('id') || !repo.hasOwnProperty('url')) {
 					throw new Error('Deploy required "id" and "url".')
 				}
-				gmd.deploy(repo.id, options.config.snapshot, function () {
-					if (cb) cb(null);
-					if (callback)callback(null);
+				gmd.deploy(repo.id, options.config.snapshot, function (err) {
+					if (cb) cb(err);
 				});
+				if (callback)callback(null);
 			});
 		});
 	}
@@ -35,10 +35,10 @@ var install = function(options, callback) {
 	if (hasValidConfig(options)) {
 		return through.obj(function(file, enc, cb) {
 			gmd.config(options.config);
-			gmd.install(function () {
-				if (cb)cb(null);
-				if (callback) callback(null);
+			gmd.install(function (err) {
+				if (cb)cb(err);
 			});
+			if (callback)callback(null);
 		});
 	}
 	throw new Error('Invalid configuration');


### PR DESCRIPTION
The way the module was written didn't allow for task chaining e.g.

``` javascript
gulp.task('default', ['build', 'maven', 'anotherthing']);
```

`anotherthing` would always execute, even if `maven` failed.
