### PR TITLE
Use the filename as ArtifactId : Add Generated Function for Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ Configuring a task for deploying to a Maven proxy
 		}))
 	});
 
+Configuring a task for deploying multiple files to a Maven proxy
+
+	var maven = require('gulp-maven-deploy');
+
+	gulp.task('deploy', function(){
+		gulp.src('*')
+        .pipe(maven.deploy(function (fileParsed) {
+                return {
+                    'config': {
+                        'groupId': 'com.mygroup',
+                        'artifactId': fileParsed.name,
+                        'type': fileParsed.extname, 
+                        'repositories': [{
+                            'id': 'some-repo-id',
+                            'url': 'http://some-repo/url'
+                        }]
+                    }
+                };
+            }
+        ))
+	});
+
 A task running a local Maven install:
 
 	var maven = require('gulp-maven-deploy');

--- a/index.js
+++ b/index.js
@@ -5,62 +5,79 @@ var gmd = require('maven-deploy');
 var through = require('through2');
 
 function hasValidConfig(options) {
-  options = options || {};
-  if (!options.hasOwnProperty('config') || typeof options.config !== 'object') {
-    throw new Error('Missing required property "config" object.');
-  }
-  return true;
+    options = options || {};
+    if (!options.hasOwnProperty('config') || typeof options.config !== 'object') {
+        throw new Error('Missing required property "config" object.');
+    }
+    return true;
+}
+
+/**
+ * Method to insure the node before version 12 of path.parse
+ * @param filePath
+ * @returns {{dir: *, base: *, ext: *, name: *}}
+ */
+function parsePathFile(filePath) {
+    var ext = path.extname(filePath);
+    var base = path.basename(filePath);
+    var basename = path.basename(filePath, ext);
+    var dirname = path.dirname(filePath);
+    return {
+        dir: dirname,
+        base: base,
+        ext: ext,
+        name: basename
+    };
 }
 
 function evalOptions(options, file, callback) {
-  var evalOptions = options;
-  if (typeof evalOptions === 'function') {
-    var relative = file.relative;
-    var parsed = path.parse(relative);
-    var extname = parsed.ext.slice(1);
-    var dirs = parsed.dir.split(path.sep);
-    // Complete current parsed
-    parsed.extname = extname;
-    parsed.file = file;
-    parsed.dirs = dirs;
-    evalOptions = evalOptions(parsed, callback);
-  }
-  return evalOptions;
+    var evalOptions = options;
+    if (typeof evalOptions === 'function') {
+        var parsed = parsePathFile(file.relative);
+        var extname = parsed.ext.slice(1);
+        var dirs = parsed.dir.split(path.sep);
+        // Complete current parsed
+        parsed.extname = extname;
+        parsed.file = file;
+        parsed.dirs = dirs;
+        evalOptions = evalOptions(parsed, callback);
+    }
+    return evalOptions;
 }
 
 var deploy = function (options, callback) {
-  return through.obj(function (file, enc, cb) {
-    options = evalOptions(options, file, callback); 
-    if (hasValidConfig(options)) {
-      gmd.config(options.config);
-      if (!options.config.hasOwnProperty('repositories')) {
-        throw new Error('Missing repositories configuration');
-      }
-      options.config.repositories.forEach(function (repo) {
-        if (!repo.hasOwnProperty('id') || !repo.hasOwnProperty('url')) {
-          throw new Error('Deploy required "id" and "url".')
+    return through.obj(function (file, enc, cb) {
+        options = evalOptions(options, file, callback);
+        if (hasValidConfig(options)) {
+            gmd.config(options.config);
+            if (!options.config.hasOwnProperty('repositories')) {
+                throw new Error('Missing repositories configuration');
+            }
+            options.config.repositories.forEach(function (repo) {
+                if (!repo.hasOwnProperty('id') || !repo.hasOwnProperty('url')) {
+                    throw new Error('Deploy required "id" and "url".')
+                }
+                gmd.deploy(repo.id, options.config.snapshot, function (err) {
+                    if (cb) cb(err);
+                });
+            });
         }
-        gmd.deploy(repo.id, options.config.snapshot, function (err) {
-          if (cb) cb(err);
-        });
-      });
-    }
-    if (callback)callback(null);
-  });
+        if (callback)callback(null);
+    });
 };
 
 var install = function (options, callback) {
-  return through.obj(function (file, enc, cb) {
-    options = evalOptions(options, file);
-    if (hasValidConfig(options)) {
-      gmd.config(options.config);
-      gmd.install(function (err) {
-        if (cb)cb(err);
-      });
-    }
-    if (callback)callback(null);
-  }); 
-  throw new Error('Invalid configuration');
+    return through.obj(function (file, enc, cb) {
+        options = evalOptions(options, file);
+        if (hasValidConfig(options)) {
+            gmd.config(options.config);
+            gmd.install(function (err) {
+                if (cb)cb(err);
+            });
+        }
+        if (callback)callback(null);
+    });
+    throw new Error('Invalid configuration');
 }
 
 module.exports.deploy = deploy.bind(this);

--- a/index.js
+++ b/index.js
@@ -1,48 +1,68 @@
 'use strict';
 
+var path = require('path');
 var gmd = require('maven-deploy');
 var through = require('through2');
 
 function hasValidConfig(options) {
-	options = options || {};
-	if (!options.hasOwnProperty('config') || typeof options.config !== 'object') {
-		throw new Error('Missing required property "config" object.');
-	}
-	return true;
+  options = options || {};
+  if (!options.hasOwnProperty('config') || typeof options.config !== 'object') {
+    throw new Error('Missing required property "config" object.');
+  }
+  return true;
 }
 
-var deploy = function(options, callback) {
-	if (hasValidConfig(options)) {
-		return through.obj(function(file, enc, cb) {
-			gmd.config(options.config);
-			if (!options.config.hasOwnProperty('repositories')) {
-				throw new Error('Missing repositories configuration');
-			}
-			options.config.repositories.forEach(function(repo) {
-				if (!repo.hasOwnProperty('id') || !repo.hasOwnProperty('url')) {
-					throw new Error('Deploy required "id" and "url".')
-				}
-				gmd.deploy(repo.id, options.config.snapshot, function (err) {
-					if (cb) cb(err);
-				});
-				if (callback)callback(null);
-			});
-		});
-	}
+function evalOptions(options, file, callback) {
+  var evalOptions = options;
+  if (typeof evalOptions === 'function') {
+    var relative = file.relative;
+    var parsed = path.parse(relative);
+    var extname = parsed.ext.slice(1);
+    var dirs = parsed.dir.split(path.sep);
+    // Complete current parsed
+    parsed.extname = extname;
+    parsed.file = file;
+    parsed.dirs = dirs;
+    evalOptions = evalOptions(parsed, callback);
+  }
+  return evalOptions;
+}
+
+var deploy = function (options, callback) {
+  return through.obj(function (file, enc, cb) {
+    options = evalOptions(options, file, callback); 
+    if (hasValidConfig(options)) {
+      gmd.config(options.config);
+      if (!options.config.hasOwnProperty('repositories')) {
+        throw new Error('Missing repositories configuration');
+      }
+      options.config.repositories.forEach(function (repo) {
+        if (!repo.hasOwnProperty('id') || !repo.hasOwnProperty('url')) {
+          throw new Error('Deploy required "id" and "url".')
+        }
+        gmd.deploy(repo.id, options.config.snapshot, function (err) {
+          if (cb) cb(err);
+        });
+      });
+    }
+    if (callback)callback(null);
+  });
 };
 
-var install = function(options, callback) {
-	if (hasValidConfig(options)) {
-		return through.obj(function(file, enc, cb) {
-			gmd.config(options.config);
-			gmd.install(function (err) {
-				if (cb)cb(err);
-			});
-			if (callback)callback(null);
-		});
-	}
-	throw new Error('Invalid configuration');
+var install = function (options, callback) {
+  return through.obj(function (file, enc, cb) {
+    options = evalOptions(options, file);
+    if (hasValidConfig(options)) {
+      gmd.config(options.config);
+      gmd.install(function (err) {
+        if (cb)cb(err);
+      });
+    }
+    if (callback)callback(null);
+  }); 
+  throw new Error('Invalid configuration');
 }
 
 module.exports.deploy = deploy.bind(this);
 module.exports.install = install.bind(this);
+

--- a/sample/gulpfile.js
+++ b/sample/gulpfile.js
@@ -27,5 +27,23 @@ gulp.task('deploy-local', function(){
 	}))
 });
 
+gulp.task('deploy-files', function () {
+    gulp.src('*')
+        .pipe(maven.deploy(function (fileParsed) {
+                return {
+                    'config': {
+                        'groupId': 'com.mygroup',
+                        'artifactId': fileParsed.name,
+                        'type': fileParsed.extname,
+                        'classifier': 'android',
+                        'repositories': [{
+                            'id': 'some-repo-id',
+                            'url': 'http://some-repo/url'
+                        }]
+                    }
+                };
+            }
+        ))
+});
 
 gulp.task('default', ['deploy-local']);


### PR DESCRIPTION
As discut at issue https://github.com/finn-no/gulp-maven-deploy/issues/5
use an function to generate the maven deploy configuration.


The use case look that
```javascript
gulp.task('deploy', function () {
  var maven = require('gulp-maven-deploy');
  gulp.src('dist/**/*.apk') 
    .pipe(maven.deploy(function (fileParsed, cb) {
        return {
          'config': {
            'groupId':  'com.mygroup',
            'artifactId': fileParsed.name,
            'type': fileParsed.extname,
            'repositories': [  {  'id': 'some-repo-id',  'url': 'http://some-repo/url' }  ]
          }
        };
      }
    ))
}); 
```